### PR TITLE
Upgrade zopfli to latest commit

### DIFF
--- a/ext/zopfli.c
+++ b/ext/zopfli.c
@@ -1,4 +1,5 @@
 #include "ruby.h"
+#include "ruby/thread.h"
 #include "zopfli.h"
 
 #define CSTR2SYM(x)    ID2SYM(rb_intern(x))

--- a/smoke.sh
+++ b/smoke.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 gem list | grep zopfli && gem uninstall --force zopfli
 bundle exec rake clean build
-gem install --force --local --no-ri --no-rdoc "$(ls pkg/zopfli-*.gem)"
+gem install --force --local --no-document "$(ls pkg/zopfli-*.gem)"
 cat <<EOF | ruby
 require 'zopfli'
 require 'zlib'

--- a/zopfli.gemspec
+++ b/zopfli.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
   spec.extensions    = ["ext/extconf.rb"]
 
-  spec.add_development_dependency "bundler", "~> 1.3"
+  spec.add_development_dependency "bundler", "~> 2.1.4"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec"
 end


### PR DESCRIPTION
I did 3 things in this PR.
- Upgrades the git submodule to the latest Zopfli version.
- Updates smoke.sh and the gemspec to use modern ruby.
- Adds #include "ruby/thread.h". This is required to build on Mac. I'm not sure why but on Linux the warning was ignored but on Mac it was breaking the build. This include is required since it defines `rb_thread_call_without_gvl`.
